### PR TITLE
tests: Force gtest static lib

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ FetchContent_Declare(
   GIT_TAG v1.16.0)
 set(INSTALL_GTEST OFF)
 set(BUILD_GMOCK OFF)
+set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(googletest)
 include(GoogleTest)
 


### PR DESCRIPTION
Force to build gtest as static library.
Fix #14 by not needing to install the shared library.