### PR TITLE
Fix logging for tests and examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_compile_definitions(LCM_LOG_DEFAULT_ENABLED=1)
-
 if(BUILD_CONNMAN)
   add_executable(connmanctl_dbus connmanctl.cpp)
   target_link_libraries(connmanctl_dbus PRIVATE GConnmanDbus)

--- a/examples/connmanctl.cpp
+++ b/examples/connmanctl.cpp
@@ -18,6 +18,7 @@ auto main() -> int {
     std::mutex cin_mutex;
     std::condition_variable cin_cv;
     bool connecting = false;
+    Amarula::Log::enable(true);
     Connman connman;
     const auto manager = connman.manager();
     manager->onRequestInputPassphrase([&](const auto& service) -> auto {

--- a/include/amarula/log.hpp
+++ b/include/amarula/log.hpp
@@ -24,11 +24,7 @@ class Log {
 
    private:
     static auto state() -> std::atomic<bool>& {
-#ifdef LCM_LOG_DEFAULT_ENABLED
-        static std::atomic<bool> flag{true};
-#else
         static std::atomic<bool> flag{false};
-#endif
         return flag;
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_compile_definitions(LCM_LOG_DEFAULT_ENABLED=1)
-
 include(FetchContent)
 FetchContent_Declare(
   googletest
@@ -22,7 +20,8 @@ install(
 if(BUILD_CONNMAN)
   foreach(connman_test gconnman_clock_test gconnman_tech_test
                        gconnman_serv_test)
-    add_executable(${connman_test} ${connman_test}.cpp qt_thread_bundle.hpp)
+    add_executable(${connman_test} ${connman_test}.cpp qt_thread_bundle.hpp
+                                   logging_init.cpp)
     target_link_libraries(${connman_test} PRIVATE GConnmanDbus gtest_main)
 
     target_include_directories(${connman_test}

--- a/tests/logging_init.cpp
+++ b/tests/logging_init.cpp
@@ -1,0 +1,9 @@
+#include <amarula/log.hpp>
+
+namespace {
+struct EnableLogging {
+    EnableLogging() { Amarula::Log::enable(true); }
+};
+
+[[maybe_unused]] EnableLogging enable_logging;
+}  // namespace


### PR DESCRIPTION
Remove the use of the LCM_LOG_DEFAULT_ENABLED compile definition. LCM_LOG has to be enable always at runtime.
Enable LCM_LOG at runtime for the tests and the example. This solves #24.